### PR TITLE
增加llvm-msvc支持，以及一些小改动

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,14 @@ Search for `ucxxrt`, choose the version that suits you, and then click "Install"
 
 IDE：Visual Studio 2022 latest version
 
+and Windows SDK
+
+and Windows Driver Kits
+
 * `git clone --recurse-submodules https://github.com/MiroKaku/ucxxrt.git`
 * Open `ucxxrt.sln` and build.
+
+* For clang-cl or llvm-msvc, you will have to add `-march=native` in the compiler flags.
 
 ## 4. Acknowledgements
 

--- a/src/crt/vcruntime/ehdata.h
+++ b/src/crt/vcruntime/ehdata.h
@@ -8,6 +8,10 @@
 #define _INC_EHDATA
 #pragma once
 
+#if defined(__clang__)
+typedef const struct _s__ThrowInfo _ThrowInfo;
+#endif
+
 #include "ehdata_values.h"
 
 #include <excpt.h>

--- a/src/crt/vcruntime/frame.cpp
+++ b/src/crt/vcruntime/frame.cpp
@@ -361,11 +361,22 @@ EXCEPTION_DISPOSITION __InternalCxxFrameHandler(
         EHTRACE_HANDLER_EXIT(ExceptionContinueSearch);
         return ExceptionContinueSearch;     // I don't think this value matters
     }
+#if defined(__clang__)
+
+#if _EH_RELATIVE_FUNCINFO
+    auto tryBlockMap = typename T::TryBlockMap(pFuncInfo, pDC->ImageBase);
+#else
+    auto tryBlockMap = typename T::TryBlockMap(pFuncInfo, 0);
+#endif
+
+#else
 
 #if _EH_RELATIVE_FUNCINFO
         auto tryBlockMap = T::TryBlockMap(pFuncInfo, pDC->ImageBase);
 #else
         auto tryBlockMap = T::TryBlockMap(pFuncInfo, 0);
+#endif
+
 #endif
     if (tryBlockMap.getNumTryBlocks() != 0
         //
@@ -614,12 +625,23 @@ static void FindHandler(
         }
     }
 
+#if defined(__clang__)
+
+#if _EH_RELATIVE_FUNCINFO
+    auto tryBlockMap = typename T::TryBlockMap(pFuncInfo, pDC->ImageBase);
+#else
+    auto tryBlockMap = typename T::TryBlockMap(pFuncInfo, 0);
+#endif
+
+#else
+
 #if _EH_RELATIVE_FUNCINFO
     auto tryBlockMap = T::TryBlockMap(pFuncInfo, pDC->ImageBase);
 #else
     auto tryBlockMap = T::TryBlockMap(pFuncInfo, 0);
 #endif
 
+#endif
     if (PER_IS_MSVC_EH(pExcept)) {
         // Looks like it's ours.  Let's see if we have a match:
         //
@@ -646,11 +668,24 @@ static void FindHandler(
 
                 // Try block was in scope for current state.  Scan catches for this
                 // try:
+#if defined(__clang__)
+
+#if _EH_RELATIVE_FUNCINFO
+                auto handlerMap = typename T::HandlerMap(&tryBlock, pDC->ImageBase, pDC->FunctionEntry->BeginAddress);
+#else
+                auto handlerMap = typename T::HandlerMap(&tryBlock, 0, 0);
+#endif
+
+#else
+
 #if _EH_RELATIVE_FUNCINFO
                 auto handlerMap = T::HandlerMap(&tryBlock, pDC->ImageBase, pDC->FunctionEntry->BeginAddress);
 #else
                 auto handlerMap = T::HandlerMap(&tryBlock, 0, 0);
 #endif
+
+#endif
+
                 for (auto handler : handlerMap)
                 {
                     // Scan all types that thrown object can be converted to:
@@ -909,6 +944,15 @@ static void FindHandlerForForeignException(
             return;
         }
     }
+#if defined(__clang__)
+
+#if _EH_RELATIVE_FUNCINFO
+    auto tryBlockMap = typename T::TryBlockMap(pFuncInfo, pDC->ImageBase);
+#else
+    auto tryBlockMap = typename T::TryBlockMap(pFuncInfo, 0);
+#endif
+
+#else
 
 #if _EH_RELATIVE_FUNCINFO
     auto tryBlockMap = T::TryBlockMap(pFuncInfo, pDC->ImageBase);
@@ -916,6 +960,7 @@ static void FindHandlerForForeignException(
     auto tryBlockMap = T::TryBlockMap(pFuncInfo, 0);
 #endif
 
+#endif
     _VCRT_VERIFY(tryBlockMap.getNumTryBlocks() > 0);
 
     if (tryBlockMap.getNumTryBlocks() > 0)
@@ -935,11 +980,24 @@ static void FindHandlerForForeignException(
             }
 
             // *and* the last catch in that try is an ellipsis (no other can be)
+#if defined(__clang__)
+
+#if _EH_RELATIVE_FUNCINFO
+            auto handlerMap = typename T::HandlerMap(&tryBlock, pDC->ImageBase, pDC->FunctionEntry->BeginAddress);
+#else
+            auto handlerMap = typename T::HandlerMap(&tryBlock, 0, 0);
+#endif
+
+#else
+
 #if _EH_RELATIVE_FUNCINFO
             auto handlerMap = T::HandlerMap(&tryBlock, pDC->ImageBase, pDC->FunctionEntry->BeginAddress);
 #else
             auto handlerMap = T::HandlerMap(&tryBlock, 0, 0);
 #endif
+
+#endif
+
             auto handler = handlerMap.getLastEntry();
             if (!(HT_IS_TYPE_ELLIPSIS(*handler) && !HT_IS_STD_DOTDOT(*handler))) {
                 continue;

--- a/src/crt/vcruntime/per_thread_data.cpp
+++ b/src/crt/vcruntime/per_thread_data.cpp
@@ -66,7 +66,7 @@ static __vcrt_ptd* __cdecl store_and_initialize_ptd(__vcrt_ptd* const ptd)
     BOOLEAN inserted = false;
 
     __vcrt_ptd* const new_ptd = static_cast<__vcrt_ptd*>(RtlInsertElementGenericTableAvl(
-        &__vcrt_startup_ptd_table, ptd, sizeof __vcrt_ptd_km, &inserted));
+        &__vcrt_startup_ptd_table, ptd, sizeof(__vcrt_ptd_km), &inserted));
 
     if (!new_ptd)
     {
@@ -77,7 +77,7 @@ static __vcrt_ptd* __cdecl store_and_initialize_ptd(__vcrt_ptd* const ptd)
     if (__get_thread_uid(PsGetCurrentThread()) != static_cast<__vcrt_ptd_km*>(new_ptd)->uid)
     {
         inserted = true;
-        RtlSecureZeroMemory(new_ptd, sizeof __vcrt_ptd); // not reset pid/uid
+        RtlSecureZeroMemory(new_ptd, sizeof(__vcrt_ptd) ); // not reset pid/uid
     }
 
     if (inserted)
@@ -92,7 +92,7 @@ static __vcrt_ptd* __cdecl store_and_initialize_ptd(__vcrt_ptd* const ptd)
 
 extern "C" bool __cdecl __vcrt_initialize_ptd()
 {
-    constexpr auto size = ROUND_TO_SIZE(sizeof __vcrt_ptd_km + sizeof RTL_BALANCED_LINKS, sizeof(void*));
+    constexpr auto size = ROUND_TO_SIZE(sizeof(__vcrt_ptd_km) + sizeof(RTL_BALANCED_LINKS), sizeof(void*));
 
     ExInitializeNPagedLookasideList(&__vcrt_startup_ptd_pools, nullptr, nullptr,
         POOL_NX_ALLOCATION, size, __ucxxrt_tag, 0);

--- a/src/crt/vcruntime/sys_common.inl
+++ b/src/crt/vcruntime/sys_common.inl
@@ -67,8 +67,9 @@ _CRTALLOC(".CRT$XIAA") static _PIFV pre_c_initializer    = pre_c_initialization;
 _CRTALLOC(".CRT$XCAA") static _PVFV pre_cpp_initializer  = pre_cpp_initialization;
 
 
-extern PDRIVER_OBJECT __drvobj     = nullptr;
+//extern PDRIVER_OBJECT __drvobj     = nullptr;
 static PDRIVER_UNLOAD __drv_unload = nullptr;
+
 static __declspec(noinline) void __scrt_common_exit(PDRIVER_OBJECT drvobj)
 {
     if (__drv_unload && __drv_unload != &__scrt_common_exit)
@@ -83,7 +84,7 @@ static __declspec(noinline) void __scrt_common_exit(PDRIVER_OBJECT drvobj)
 
 static __declspec(noinline) long __cdecl __scrt_common_main_seh(PDRIVER_OBJECT drvobj, PUNICODE_STRING regpath)
 {
-    __drvobj = drvobj;
+//    __drvobj = drvobj;
 
     if (!__scrt_initialize_crt())
         __scrt_fastfail(FAST_FAIL_FATAL_APP_EXIT);
@@ -102,7 +103,7 @@ static __declspec(noinline) long __cdecl __scrt_common_main_seh(PDRIVER_OBJECT d
         long const main_result = invoke_main(drvobj, regpath);
         if (NT_SUCCESS(main_result))
         {
-            if (drvobj->DriverUnload)
+            if (drvobj && drvobj->DriverUnload)
             {
                 __drv_unload = drvobj->DriverUnload;
                 drvobj->DriverUnload = &__scrt_common_exit;

--- a/src/ucrt/internal/per_thread_data.cpp
+++ b/src/ucrt/internal/per_thread_data.cpp
@@ -67,7 +67,7 @@ static __acrt_ptd* __cdecl store_and_initialize_ptd(__acrt_ptd* const ptd)
     BOOLEAN inserted = false;
 
     __acrt_ptd* const new_ptd = static_cast<__acrt_ptd*>(RtlInsertElementGenericTableAvl(
-        &__acrt_startup_ptd_table, ptd, sizeof __acrt_ptd_km, &inserted));
+        &__acrt_startup_ptd_table, ptd, sizeof(__acrt_ptd_km), &inserted));
     if (!new_ptd)
     {
         return nullptr;
@@ -77,7 +77,7 @@ static __acrt_ptd* __cdecl store_and_initialize_ptd(__acrt_ptd* const ptd)
     if (__get_thread_uid(PsGetCurrentThread()) != static_cast<__acrt_ptd_km*>(new_ptd)->uid)
     {
         inserted = true;
-        RtlSecureZeroMemory(new_ptd, sizeof __acrt_ptd); // not reset pid/uid
+        RtlSecureZeroMemory(new_ptd, sizeof(__acrt_ptd)); // not reset pid/uid
     }
 
     return new_ptd;
@@ -85,7 +85,7 @@ static __acrt_ptd* __cdecl store_and_initialize_ptd(__acrt_ptd* const ptd)
 
 extern "C" bool __cdecl __acrt_initialize_ptd()
 {
-    constexpr auto size = ROUND_TO_SIZE(sizeof __acrt_ptd_km + sizeof RTL_BALANCED_LINKS, sizeof(void*));
+    constexpr auto size = ROUND_TO_SIZE(sizeof(__acrt_ptd_km) + sizeof(RTL_BALANCED_LINKS), sizeof(void*));
 
     ExInitializeNPagedLookasideList(&__acrt_startup_ptd_pools, nullptr, nullptr,
         POOL_NX_ALLOCATION, size, __ucxxrt_tag, 0);

--- a/src/ucrt/misc/invalid_parameter.cpp
+++ b/src/ucrt/misc/invalid_parameter.cpp
@@ -32,7 +32,7 @@ extern "C" void __cdecl __acrt_initialize_invalid_parameter_handler(void* const 
 //
 //-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-extern "C" static void __cdecl _invalid_parameter_internal(
+extern "C" void __cdecl _invalid_parameter_internal(
     wchar_t const*     const expression,
     wchar_t const*     const function_name,
     wchar_t const*     const file_name,

--- a/src/ucrt/startup/exit.cpp
+++ b/src/ucrt/startup/exit.cpp
@@ -31,7 +31,8 @@ static int __cdecl atexit_exception_filter(unsigned long const _exception_code) 
     return EXCEPTION_CONTINUE_SEARCH;
 }
 
-extern PDRIVER_OBJECT __drvobj;
+//extern PDRIVER_OBJECT __drvobj;
+
 static void __cdecl common_exit(
     int                    const /*return_code*/,
     _crt_exit_cleanup_mode const cleanup_mode,

--- a/src/ucrt/stdlib/rotl.cpp
+++ b/src/ucrt/stdlib/rotl.cpp
@@ -22,6 +22,7 @@
 #endif
 
 
+#if !defined(__clang__)
 
 extern "C" unsigned long __cdecl _lrotl(unsigned long value, int shift)
 {
@@ -43,3 +44,5 @@ extern "C" unsigned __int64 __cdecl _rotl64(unsigned __int64 value, int shift)
     value = (value >> (0x40 - shift)) | (value << shift);
     return value;
 }
+
+#endif

--- a/src/ucrt/stdlib/rotr.cpp
+++ b/src/ucrt/stdlib/rotr.cpp
@@ -22,6 +22,8 @@
 #endif
 
 
+#if !defined(__clang__)
+
 
 extern "C" unsigned long __cdecl _lrotr(unsigned long value, int shift)
 {
@@ -43,3 +45,5 @@ extern "C" unsigned __int64 __cdecl _rotr64(unsigned __int64 value, int shift)
     value = (value << (0x40 - shift)) | (value >> shift);
     return value;
 }
+
+#endif

--- a/src/ucxxrt.props
+++ b/src/ucxxrt.props
@@ -42,7 +42,10 @@
 
   <PropertyGroup>
     <UCXXRT_KernelMode>false</UCXXRT_KernelMode>
-    <UCXXRT_KernelMode Condition=" ('$(PlatformToolset.TrimEnd(`0123456789.`))' == 'WindowsKernelModeDriver') ">true</UCXXRT_KernelMode>
+    <UCXXRT_KernelMode Condition="('$(PlatformToolset.TrimEnd(`0123456789.`))' == 'WindowsKernelModeDriver') Or 
+    ('$(PlatformToolset)' == 'LLVM-MSVC_v143_KernelMode') Or 
+    ('$(PlatformToolset)' == 'LLVM-MSVC_v142_KernelMode') Or 
+    ('$(PlatformToolset)' == 'LLVM-MSVC_v141_KernelMode') ">true</UCXXRT_KernelMode>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/ucxxrtlib.props
+++ b/src/ucxxrtlib.props
@@ -44,7 +44,10 @@ xcopy /D /S /Y /V /F "$(SolutionDir)lib" "$(SolutionDir)ucxxrt\lib\" /EXCLUDE:$(
   <!-- ucxxrt Config -->
   <PropertyGroup>
     <UCXXRT_KernelMode>false</UCXXRT_KernelMode>
-    <UCXXRT_KernelMode Condition=" ('$(PlatformToolset.TrimEnd(`0123456789.`))' == 'WindowsKernelModeDriver') ">true</UCXXRT_KernelMode>
+    <UCXXRT_KernelMode Condition="('$(PlatformToolset.TrimEnd(`0123456789.`))' == 'WindowsKernelModeDriver') Or 
+    ('$(PlatformToolset)' == 'LLVM-MSVC_v143_KernelMode') Or 
+    ('$(PlatformToolset)' == 'LLVM-MSVC_v142_KernelMode') Or 
+    ('$(PlatformToolset)' == 'LLVM-MSVC_v141_KernelMode') ">true</UCXXRT_KernelMode>
   </PropertyGroup>
 
   <PropertyGroup Condition=" ('$(UCXXRT_KernelMode)'=='true') ">


### PR DESCRIPTION
1、修改一些源码中对clang系编译器不兼容的地方（此处特指llvm-msvc）

2、prop中现在支持自动识别名为 `LLVM-MSVC_v143_KernelMode` and `LLVM-MSVC_v142_KernelMode` and `LLVM-MSVC_v141_KernelMode`的PlatformToolset

3、README.md中增加一条需要手动添加编译选项`-march=native`的提示。（懒得改vcxproj了）

4、在crt main中访问DriverObject之前，先检查DriverObject合法性，防止驱动以无模块形式加载时直接爆炸